### PR TITLE
Feature/haxe3 refactor

### DIFF
--- a/src/main/haxe/funk/futures/Promise.hx
+++ b/src/main/haxe/funk/futures/Promise.hx
@@ -113,6 +113,7 @@ class PromiseTypes {
                         switch (attempt) {
                             case Failure(e): deferred.reject(e);
                             case Success(v): deferred.resolve(v);
+                            case _: deferred.reject(IllegalOperationError());
                         }
                     });
 
@@ -120,6 +121,7 @@ class PromiseTypes {
                         deferred.progress(0.5 + value * 0.5);
                     });
 
+                case _: deferred.reject(IllegalOperationError());
             }
         });
         promise.progress(function (value : Float) {
@@ -137,6 +139,7 @@ class PromiseTypes {
             switch (attempt) {
                 case Failure(e): deferred.reject(e);
                 case Success(p): pipe(p, deferred);
+                case _: deferred.reject(IllegalOperationError());
             }
         });
 
@@ -170,6 +173,7 @@ class PromiseTypes {
                 switch (attempt) {
                     case Failure(e): deferred.reject(e);
                     case Success(v): value0 = Some(v);
+                    case _: deferred.reject(IllegalOperationError());
                 }
 
                 check();
@@ -181,6 +185,7 @@ class PromiseTypes {
                 switch (attempt) {
                     case Failure(e): deferred.reject(e);
                     case Success(v): value1 = Some(v);
+                    case _: deferred.reject(IllegalOperationError());
                 }
 
                 check();
@@ -199,6 +204,7 @@ class PromiseTypes {
             switch (attempt) {
                 case Failure(error): deferred.reject(error);
                 case Success(value): deferred.resolve(value);
+                case _: deferred.reject(IllegalOperationError());
             }
         });
 
@@ -213,6 +219,7 @@ class PromiseTypes {
             switch (attempt) {
                 case Failure(error): deferred.reject(error);
                 case Success(value): deferred.resolve(func(value));
+                case _: deferred.reject(IllegalOperationError());
             }
         });
 

--- a/src/main/haxe/funk/io/logging/Log.hx
+++ b/src/main/haxe/funk/io/logging/Log.hx
@@ -21,7 +21,11 @@ class Log {
 
     public static function streamOut() : Stream<Message<AnyRef>> return defaultLogger.streamOut();
 
+    @:note("#0b1kn00b: Use of this without init causes infinite loop in nodejs when used from ActorSystem: go figure.")
     public static function log<T>(output : LogValue<T>) : LogValue<T> {
+        if(defaultLogger == null){
+            init();
+        }
         Log.streamIn().dispatch(output);
         return output;
     }

--- a/src/main/haxe/funk/ioc/Inject.hx
+++ b/src/main/haxe/funk/ioc/Inject.hx
@@ -24,6 +24,7 @@ class Inject {
             case _: with(type);
         };
     }
+
     @:noUsing
     public static function with<T>(type : Class<T>) : Option<T> {
         if (type.toBool().not()) Funk.error(ArgumentError());

--- a/src/main/haxe/funk/reactives/Process.hx
+++ b/src/main/haxe/funk/reactives/Process.hx
@@ -143,7 +143,7 @@ class Task {
             var msg = Thread.readMessage(false);
             if (msg == "stop") {
                 shouldStop = true;
-                id = false;
+                id = null;
             }
         }
     }

--- a/src/main/haxe/funk/reactives/Process.hx
+++ b/src/main/haxe/funk/reactives/Process.hx
@@ -13,7 +13,7 @@ import cpp.vm.Thread;
 
 class Process {
 
-    #if hx_node_api
+    #if nodejs
     #elseif js 
     private static var _performance = untyped __js__('performance || {}; 
             performance.now = (function() {
@@ -52,7 +52,7 @@ class Process {
     inline
     #end
     public static function stamp() : Float {
-        #if hx_node_api
+        #if nodejs
         return Date.now().getTime();
         #elseif js
         return _performance.now(); 

--- a/src/main/haxe/funk/types/Attempt.hx
+++ b/src/main/haxe/funk/types/Attempt.hx
@@ -76,6 +76,7 @@ class AttemptTypes {
         return switch(attempt) {
             case Success(value): value;
             case Failure(value): Failure(value);
+            case _: Failure(Error("Failure"));
         }
     }
 
@@ -100,6 +101,7 @@ class AttemptTypes {
         return switch(attempt) {
             case Success(value): funcSuccess(value);
             case Failure(error): funcFailure(error);
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -124,6 +126,7 @@ class AttemptTypes {
         return switch(attempt) {
             case Success(value): Success(funcSuccess(value));
             case Failure(value): Failure(funcFailure(value));
+            case _: Failure(Error("Failure"));
         }
     }
 
@@ -157,6 +160,7 @@ class AttemptTypes {
                     case Failure(right1): AnyTypes.equals(right0, right1, funcFailure);
                     case _: false;
                 }
+            case _: false;
         }
     }
 
@@ -164,6 +168,7 @@ class AttemptTypes {
         return switch(attempt) {
             case Success(value): Right(value);
             case Failure(value): Left(value);
+            case _: Left(Error("Failure"));
         }
     }
 
@@ -191,6 +196,7 @@ class AttemptTypes {
         return switch (attempt) {
             case Success(value): 'Success(${AnyTypes.toString(value, funcSuccess)})';
             case Failure(value): 'Failure(${AnyTypes.toString(value, funcFailure)})';
+            case _: 'Failure(Invalid)';
         }
     }
 }

--- a/src/main/haxe/funk/types/Either.hx
+++ b/src/main/haxe/funk/types/Either.hx
@@ -68,6 +68,7 @@ class EitherTypes {
         return switch(either) {
             case Left(value): Right(value);
             case Right(value): Left(value);
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -75,6 +76,7 @@ class EitherTypes {
         return switch(either) {
             case Left(value): value;
             case Right(value): value;
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -99,6 +101,7 @@ class EitherTypes {
         return switch(either) {
             case Left(value): funcLeft(value);
             case Right(value): funcRight(value);
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -123,6 +126,7 @@ class EitherTypes {
         return switch(either) {
             case Left(value): Left(funcLeft(value));
             case Right(value): Right(funcRight(value));
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -156,6 +160,7 @@ class EitherTypes {
                     case Right(right1): AnyTypes.equals(right0, right1, funcRight);
                     case _: false;
                 }
+            case _: false;
         }
     }
 
@@ -190,6 +195,7 @@ class EitherTypes {
         return switch (either) {
             case Left(value): 'Left(${AnyTypes.toString(value, funcLeft)})';
             case Right(value): 'Right(${AnyTypes.toString(value, funcRight)})';
+            case _: 'Left(Invalid)';
         }
     }
 }

--- a/src/main/haxe/funk/types/Option.hx
+++ b/src/main/haxe/funk/types/Option.hx
@@ -110,6 +110,7 @@ class OptionTypes {
                     case Some(_): false;
                     case _: true;
                 }
+            case _: false;
         }
     }
 

--- a/src/main/haxe/funk/types/Tuple1.hx
+++ b/src/main/haxe/funk/types/Tuple1.hx
@@ -32,7 +32,9 @@ class Tuple1Types {
             case tuple1(t1_0):
                 switch (b) {
                     case tuple1(t1_1): AnyTypes.equals(t1_0, t1_1, func);
+                    case _: false;
                 }
+            case _: false;
         }
     }
 

--- a/src/main/haxe/funk/types/Tuple2.hx
+++ b/src/main/haxe/funk/types/Tuple2.hx
@@ -36,6 +36,7 @@ class Tuple2Types {
     public static function swap<T1, T2>(tuple : Tuple2<T1, T2>) : Tuple2<T2, T1> {
         return switch (tuple) {
             case tuple2(a, b): tuple2(b, a);
+            case _: Funk.error(IllegalOperationError());
         }
     }
 
@@ -48,7 +49,9 @@ class Tuple2Types {
             case tuple2(t1_0, t2_0):
                 switch (b) {
                     case tuple2(t1_1, t2_1): AnyTypes.equals(t1_0, t1_1, func1) && AnyTypes.equals(t2_0, t2_1, func2);
+                    case _: false;
                 }
+            case _: false;
         }
     }
 

--- a/src/main/haxe/funk/types/Tuple3.hx
+++ b/src/main/haxe/funk/types/Tuple3.hx
@@ -51,7 +51,9 @@ class Tuple3Types {
                     case tuple3(t1_1, t2_1, t3_1):
                         AnyTypes.equals(t1_0, t1_1, func1) && AnyTypes.equals(t2_0, t2_1, func2) &&
                             AnyTypes.equals(t3_0, t3_1, func3);
+                    case _: false;
                 }
+            case _: false;
         }
     }
 


### PR DESCRIPTION
Best to leave pattern matching compatability at 3.0, so reverted that (in the proper fashion, can revert the revert come 3.1)

please check `id = null` in Process, setting Thread to false is something I'm not sure about.

Tracked down the node bug to a null in Log.log, hope it's not too much of a hack to check, will leave that out if need be.
